### PR TITLE
Add 'Benchmarking GNNs' paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 ## [Models](#content)   
 
 ### [Basic Models](#content)
-1. **Supervised Neural Networks for the Classification of Structures.** arxiv 2020. [paper](https://ieeexplore.ieee.org/abstract/document/572108)
+1. **Supervised Neural Networks for the Classification of Structures.** IEEE TNN 1997. [paper](https://ieeexplore.ieee.org/abstract/document/572108)
 
     *Alessandro Sperduti and Antonina Starita.*
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,16 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 1. **The Graph Neural Network Model.** IEEE TNN 2009. [paper](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=4700287)
 
     *Scarselli, Franco and Gori, Marco and Tsoi, Ah Chung and Hagenbuchner, Markus and Monfardini, Gabriele.*
+    
+1. **Benchmarking Graph Neural Networks** arxiv 2020. [paper](https://arxiv.org/pdf/2003.00982.pdf)
+
+    *Dwivedi, Vijay Prakash and Joshi, Chaitanya K. and Laurent, Thomas and Bengio, Yoshua and Bresson, Xavier*
 
 
 ## [Models](#content)   
 
 ### [Basic Models](#content)
-1. **Supervised Neural Networks for the Classification of Structures.** IEEE TNN 1997. [paper](https://ieeexplore.ieee.org/abstract/document/572108)
+1. **Supervised Neural Networks for the Classification of Structures.** arxiv 2020. [paper](https://ieeexplore.ieee.org/abstract/document/572108)
 
     *Alessandro Sperduti and Antonina Starita.*
 


### PR DESCRIPTION
Add 'Benchmarking GNNs' paper under 'Surveys'

**Benchmarking Graph Neural Networks**

*Vijay Prakash Dwivedi, Chaitanya K. Joshi, Thomas Laurent, Yoshua Bengio, Xavier Bresson*

>  Graph neural networks (GNNs) have become the standard toolkit for analyzing and learning from data on graphs. They have been successfully applied to a myriad of domains including chemistry, physics, social sciences, knowledge graphs, recommendation, and neuroscience. As the field grows, it becomes critical to identify the architectures and key mechanisms which generalize across graphs sizes, enabling us to tackle larger, more complex datasets and domains. Unfortunately, it has been increasingly difficult to gauge the effectiveness of new GNNs and compare models in the absence of a standardized benchmark with consistent experimental settings and large datasets. In this paper, we propose a reproducible GNN benchmarking framework, with the facility for researchers to add new datasets and models conveniently. We apply this benchmarking framework to novel medium-scale graph datasets from mathematical modeling, computer vision, chemistry and combinatorial problems to establish key operations when designing effective GNNs. Precisely, graph convolutions, anisotropic diffusion, residual connections and normalization layers are universal building blocks for developing robust and scalable GNNs. 

https://arxiv.org/abs/2003.00982