### PR TITLE
Add survey on GNNs for dynamic graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
     *Dwivedi, Vijay Prakash and Joshi, Chaitanya K. and Laurent, Thomas and Bengio, Yoshua and Bresson, Xavier.*
 
+1. **Foundations and modelling of dynamic networks using Dynamic Graph Neural Networks: A survey.** arxiv 2020. [paper](https://arxiv.org/abs/2005.07496)
+
+    *Skarding, Joakim and Gabrys, Bogdan and Musial, Katarzyna.*
+
 
 ## [Models](#content)   
 


### PR DESCRIPTION
I've recently shared our new survey on arxiv: [Foundations and modelling of dynamic networks using Dynamic Graph Neural Networks: A survey
](https://arxiv.org/abs/2005.07496) We survey GNNs for dynamic graphs, and refer to these GNNs as dynamic graph neural networks (DGNN). DGNNs are, as far as I'm aware, not covered by other surveys on this list. Thus adding this paper to the list will make the list more comprehensive and spread awareness of the advances of DGNNs.

Thank you for your consideration.
