### PR TITLE
add three neurips papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,10 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ruochi Zhang, Yuesong Zou, Jian Ma.*
 
+1. **Subgraph Neural Networks.** NeurIPS 2020. [paper](https://papers.nips.cc/paper/2020/hash/5bca8566db79f3788be9efd96c9ed70d-Abstract.html)
+
+    *Emily Alsentzer, Samuel Finlayson, Michelle Li, Marinka Zitnik.*
+
 ### [Pooling Methods](#content)
 1. **An End-to-End Deep Learning Architecture for Graph Classification.** AAAI 2018. [paper](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/17146/16755)
 
@@ -1606,6 +1610,10 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Xuanqing Liu, Si Si, Jerry Zhu, Yang Li, Cho-Jui Hsieh.*
 
+1. **GNNGuard: Defending Graph Neural Networks against Adversarial Attacks.** NeurIPS 2020. [paper](https://papers.nips.cc/paper/2020/hash/690d83983a63aa1818423fd6edd3bfdb-Abstract.html)
+
+    *Xiang Zhang, Marinka Zitnik.*
+
 ### [Graph Clustering](#content)
 
 1. **Attributed Graph Clustering: A Deep Attentional Embedding Approach.** IJCAI 2019. [paper](https://arxiv.org/pdf/1906.06532.pdf)
@@ -1790,6 +1798,10 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 1. **Learning to Extrapolate Knowledge: Transductive Few-shot Out-of-Graph Link Prediction.** NeurIPS 2020. [paper](https://arxiv.org/abs/2006.06648)
 
 	*Jinheon Baek, Dong Bok Lee, Sung Ju Hwang.*
+
+1. **Graph Meta Learning via Local Subgraphs.** NeurIPS 2020. [paper](https://papers.nips.cc/paper/2020/hash/412604be30f701b1b1e3124c252065e6-Abstract.html)
+
+    *Kexin Huang, Marinka Zitnik.*
 
 ### [Program Representation](#content)
 


### PR DESCRIPTION
Hi, thanks for this great resource! I would like to point out three papers in NeurIPS from our lab. Please let me know if the categorizations of them are okay!

Graph Meta Learning via Local Subgraphs. -> Few-shot learning.
GNNGuard: Defending Graph Neural Networks against Adversarial Attacks. -> Adversarial Attacks.
Subgraph Neural Networks. -> Graph Types.


Kexin