### PR TITLE
Add two paper on GNN and CO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,14 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
+1. **Learning to Solve NP-Complete Problems - A Graph Neural Network for Decision TSP.** AAAI 2019. [paper](https://arxiv.org/pdf/1809.02721.pdf)
+
+	*Marcelo O. R. Prates, Pedro H. C. Avelar, Henrique Lemos, Luis Lamb, Moshe Vardi.*
+
+1. **Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning.** arXiv 2019. [paper](https://arxiv.org/pdf/1911.04936.pdf)
+
+	*Qiang Ma, Suwen Ge, Danyang He, Darshan Thaker, Iddo Drori.*
+
 ### [Adversarial Attack](#content)
 1. **Adversarial Attacks on Neural Networks for Graph Data.** KDD 2018. [paper](http://delivery.acm.org/10.1145/3230000/3220078/p2847-zugner.pdf?ip=101.5.139.169&id=3220078&acc=ACTIVE%20SERVICE&key=BF85BBA5741FDC6E%2E587F3204F5B62A59%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&__acm__=1545706391_e7484be677293ffb5f18b39ce84a0df9)
 

--- a/README.md
+++ b/README.md
@@ -1561,9 +1561,9 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
-1. **Learning to Solve NP-Complete Problems - A Graph Neural Network for Decision TSP.** AAAI 2019. [paper](https://arxiv.org/pdf/1809.02721.pdf)
+1. **Automatic Virtual Network Embedding.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
 
-	*Marcelo O. R. Prates, Pedro H. C. Avelar, Henrique Lemos, Luis Lamb, Moshe Vardi.*
+	*Zhongxia Yan, Jingguo Ge, Yulei Wu, Liangxiong Li, Tong Li.*
 
 1. **Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning.** arXiv 2019. [paper](https://arxiv.org/pdf/1911.04936.pdf)
 

--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
-1. **Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
+1. **Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks.** JASC 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
 
 	*Zhongxia Yan, Jingguo Ge, Yulei Wu, Liangxiong Li, Tong Li.*
 

--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
-1. **Automatic Virtual Network Embedding.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
+1. **Automatic virtual network embedding: A deep reinforcement learning approach with graph convolutional networks.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
 
 	*Zhongxia Yan, Jingguo Ge, Yulei Wu, Liangxiong Li, Tong Li.*
 

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 1. **Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning.** arXiv 2019. [paper](https://arxiv.org/pdf/1911.04936.pdf)
 
-	*Qiang Mb, Suwen Ge, Danyang He, Darshan Thaker, Iddo Drori.*
+	*Qiang Ma, Suwen Ge, Danyang He, Darshan Thaker, Iddo Drori.*
 
 ### [Adversarial Attack](#content)
 1. **Adversarial Attacks on Neural Networks for Graph Data.** KDD 2018. [paper](http://delivery.acm.org/10.1145/3230000/3220078/p2847-zugner.pdf?ip=101.5.139.169&id=3220078&acc=ACTIVE%20SERVICE&key=BF85BBA5741FDC6E%2E587F3204F5B62A59%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&__acm__=1545706391_e7484be677293ffb5f18b39ce84a0df9)

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 1. **Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning.** arXiv 2019. [paper](https://arxiv.org/pdf/1911.04936.pdf)
 
-	*Qiang Ma, Suwen Ge, Danyang He, Darshan Thaker, Iddo Drori.*
+	*Qiang Mb, Suwen Ge, Danyang He, Darshan Thaker, Iddo Drori.*
 
 ### [Adversarial Attack](#content)
 1. **Adversarial Attacks on Neural Networks for Graph Data.** KDD 2018. [paper](http://delivery.acm.org/10.1145/3230000/3220078/p2847-zugner.pdf?ip=101.5.139.169&id=3220078&acc=ACTIVE%20SERVICE&key=BF85BBA5741FDC6E%2E587F3204F5B62A59%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&__acm__=1545706391_e7484be677293ffb5f18b39ce84a0df9)

--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
-1. **Automatic virtual network embedding: A deep reinforcement learning approach with graph convolutional networks.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
+1. **Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks.** INFOCOM 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
 
 	*Zhongxia Yan, Jingguo Ge, Yulei Wu, Liangxiong Li, Tong Li.*
 

--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
 	*Ryoma Sato, Makoto Yamada, Hisashi Kashima.*
 
-1. **Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks.** JASC 2020. [paper](https://ieeexplore.ieee.org/document/9060910.pdf)
+1. **Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks.** JASC 2020. [paper](https://ieeexplore.ieee.org/document/9060910)
 
 	*Zhongxia Yan, Jingguo Ge, Yulei Wu, Liangxiong Li, Tong Li.*
 


### PR DESCRIPTION
There are two papers on GNN and Combinatorial Optimization:
Automatic Virtual Network Embedding: A Deep Reinforcement Learning Approach with Graph Convolutional Networks. JASC 2020
Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning. arXiv 2019.12 from Columbia University.

They utilize different GNNs to solve two combinatorial optimization problems, VNE and TSP. Please include them in this repository and thanks for your efforts to maintain it.

Best wishes,
GeminiLight